### PR TITLE
(^) Fixes #4

### DIFF
--- a/try.php
+++ b/try.php
@@ -159,7 +159,7 @@
           if($(this).attr("id") === "ceu-next"){
             Slides.next();
           }
-          else {
+          else if($(this).attr("id") === "ceu-left"){
             Slides.previous();
           }    
         });


### PR DESCRIPTION
The selector used to capture a click on the `Next` or `Previous` buttons also captured clicks on the `Index` button. Hence, when this button was clicked the handler for `Next`/`Previous` was executed and, as the button id was not `ceu-next`, it would load the previous slide. By checking if the click's target was the `Previous` button this unexpected behavior is eliminated.
